### PR TITLE
Thredds over ssl

### DIFF
--- a/ansible/jupyterhub-nginx.conf
+++ b/ansible/jupyterhub-nginx.conf
@@ -35,6 +35,23 @@ server {
     ssl_stapling_verify on;
     add_header Strict-Transport-Security max-age=15768000;
 
+    # Put the location stuff here, until we figure out how to separate it into their own files
+
+    # Proxy THREDDS requests to the internal server
+	# Protect with PAM authentication, which is the same as the Jupyter login
+	# Allow non-authenticated use of ssl within the HPCCloud domain, so that
+	# Jupyter extensions can use the THREDDS server with ssl.
+    location /thredds/ {
+        satisfy any;
+        allow 145.100.57.0/22;
+        auth_pam              "THREDDS server";
+        auth_pam_service_name "nginx";
+        proxy_pass http://localhost:8080/thredds/;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     # Managing literal requests to the JupyterHub front end
     location / {
         proxy_pass http://127.0.0.1:8000;

--- a/ansible/nginx.yml
+++ b/ansible/nginx.yml
@@ -3,7 +3,7 @@
 
 - name: Install nginx
   apt:
-    name: [nginx]
+    name: [nginx, libnginx-mod-http-auth-pam]
 
 - name: Generate Diffie Hellman parameters; takes a few minutes
   shell: openssl dhparam -out /etc/ssl/certs/dhparam.pem 4096
@@ -21,3 +21,6 @@
     src: /etc/nginx/sites-available/jupyterhub.conf
     dest: /etc/nginx/sites-enabled/jupyterhub.conf
     state: link
+
+- name: Add www-data to shadow, to be able to read the password file for PAM authentication
+  shell: usermod -a -G shadow www-data


### PR DESCRIPTION
Set up THREDDS proxied through Nginx, for separate internal and external permissions